### PR TITLE
Split the response from 'puppet cert' with String#lines

### DIFF
--- a/util/puppetca/puppetca.rb
+++ b/util/puppetca/puppetca.rb
@@ -62,7 +62,7 @@ module MCollective
 
         Shell.new('%s list --all --color=none' % @puppetca, :stdout => output).runcommand
 
-        output.each do |line|
+        output.lines do |line|
           result = line.gsub("\"", '').split("\s")
 
           if result[0] == '+'


### PR DESCRIPTION
In version:
  Puppet v3.6.2 (Puppet Enterprise 3.3.2)

We found that the agent returned an error:

peadmin@pm-d1:~$ mco rpc -v puppetca list -I puppetdev.localnet
- [ ============================================================> ] 1 / 1

puppetdev.localnet                   : undefined method `each' for #<String:0x007f5b2ca89600>
    undefined method`each' for #String:0x007f5b2ca89600

---- puppetca#list call stats ----
           Nodes: 1 / 1
     Pass / Fail: 0 / 1
      Start Time: 2014-11-11 13:02:22 +0000
  Discovery Time: 0.00ms
      Agent Time: 3428.28ms
      Total Time: 3428.28ms
peadmin@pm-d1:~$ 

It looks like MCollective::Util::Puppetca#certificates was trying to loop round
each line returned by:

Shell.new('%s list --all --color=none' % @puppetca, :stdout => output).runcommand

This commit just splits the string by String#lines rather than trying to use each.

Now we get:

peadmin@pm-d1:~$ mco rpc -v puppetca list -I puppetdev.localnet
- [ ============================================================> ] 1 / 1

puppetdev.localnet                   : OK
    {:requests=>[],     :signed=>      ["admw000003",       "admw000004",       "admw000007",       "admw000008",       "admw000009",       "admw000010",       "admw000011",       "admw000014",       "pe-internal-broker",       "pe-internal-dashboard",       "pe-internal-mcollective-servers",       "pe-internal-peadmin-mcollective-client",       "pe-internal-puppet-console-mcollective-client",       "puppetdev.localnet"]}

---- puppetca#list call stats ----
           Nodes: 1 / 1
     Pass / Fail: 1 / 0
      Start Time: 2014-11-11 13:03:43 +0000
  Discovery Time: 0.00ms
      Agent Time: 3666.43ms
      Total Time: 3666.43ms
peadmin@pm-d1:~$ 
